### PR TITLE
修复“干员秘闻”期数错误的问题

### DIFF
--- a/docs/posts/2024-02/README.md
+++ b/docs/posts/2024-02/README.md
@@ -23,6 +23,6 @@ title: Vol. 19 - 2024 年 02 月号
 - **创作者访谈**
   - [特别专访：粽子淞](interview.html)
 - **干员秘闻**
-  - [干员秘闻：第十三期](ope_sec.html)
+  - [干员秘闻：第十四期](ope_sec.html)
 
 <FakeAds />

--- a/docs/posts/2024-03/README.md
+++ b/docs/posts/2024-03/README.md
@@ -21,6 +21,6 @@ title: Vol. 20 - 2024 年 03 月号：希望的诸多表现形式
   - [漫画一则](comic1.html)
   - [画中秘境](paintings.html)
 - **干员秘闻**
-  - [干员秘闻：第十三期](ope_sec.html)
+  - [干员秘闻：第十五期](ope_sec.html)
 
 <FakeAds />


### PR DESCRIPTION
- 修复 Vol.19 与 Vol.20 的期刊目录页中，“干员秘闻”期数错误的问题